### PR TITLE
Change writeFile to writeFileSync to remove deprecated warning.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ ChunkHashReplacePlugin.prototype.apply = function (compiler) {
       const stats = statsData.toJson();
       const template = fs.readFileSync(src, 'utf8');
       const htmlOutput = transform(template, stats.chunks);
-      fs.writeFile(dest, htmlOutput);
+      fs.writeFileSync(dest, htmlOutput);
     });
   });
 };


### PR DESCRIPTION
When using latest chunkhash-replace-webpack-plugin from nppmjs.org (version 0.0.23) and Node version 7+ there is a warning:
![deprecated-warning](https://user-images.githubusercontent.com/19742131/28992740-bd022bf2-79ce-11e7-895b-cbbe1eff03e1.png)

Just need to use 'writeFileSync' instead of 'writeFile'.