### PR TITLE
Don't fail with "undefined" output body

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -13,7 +13,7 @@ function transform(template, chunks) {
                 .split('.')
                 .slice(0, -1)
                 .join('')
-                .replace(/[^a-z0-9_]/gi, '');
+                .replace(/[^a-z0-9_$]/gi, '');
 
             let regex = null;
             switch (extension) {
@@ -26,7 +26,7 @@ function transform(template, chunks) {
                     break;
                 }
                 default:
-                    return;
+                    continue;
             }
 
             htmlOutput = htmlOutput.replace(regex, `$1${file}$3`);


### PR DESCRIPTION
1.) Correct bad failure if .map files are emitted for chunks, returning `undefined`.  
2.) Allow `$` in filenames. 

Fixes https://github.com/giemch/chunkhash-replace-webpack-plugin/issues/5